### PR TITLE
Introduce MockTestcontainersConfigurationExtension

### DIFF
--- a/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
+++ b/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
@@ -1,11 +1,10 @@
 package org.testcontainers;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.dockerclient.LogToStringContainerCallback;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.MockTestcontainersConfigurationRule;
+import org.testcontainers.utility.MockTestcontainersConfigurationExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -13,11 +12,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Test for {@link DockerClientFactory}.
  */
-@Testcontainers
+@ExtendWith(MockTestcontainersConfigurationExtension.class)
 public class DockerClientFactoryTest {
-
-    @Container
-    public MockTestcontainersConfigurationRule configurationMock = new MockTestcontainersConfigurationRule();
 
     @Test
     public void runCommandInsideDockerShouldNotFailIfImageDoesNotExistsLocally() {

--- a/core/src/test/java/org/testcontainers/containers/ReusabilityUnitTests.java
+++ b/core/src/test/java/org/testcontainers/containers/ReusabilityUnitTests.java
@@ -9,27 +9,26 @@ import com.github.dockerjava.api.command.InspectContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.ListContainersCmd;
 import com.github.dockerjava.api.command.StartContainerCmd;
+import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.core.command.CreateContainerCmdImpl;
 import com.github.dockerjava.core.command.InspectContainerCmdImpl;
 import com.github.dockerjava.core.command.ListContainersCmdImpl;
 import com.github.dockerjava.core.command.StartContainerCmdImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-import org.junit.Rule;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
 import org.mockito.Answers;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.TestImages;
 import org.testcontainers.containers.startupcheck.StartupCheckStrategy;
+import org.testcontainers.containers.startupcheck.StartupCheckStrategy.StartupStatus;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
-import org.testcontainers.utility.MockTestcontainersConfigurationRule;
+import org.testcontainers.utility.MockTestcontainersConfigurationExtension;
 import org.testcontainers.utility.MountableFile;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
@@ -55,13 +54,13 @@ import static org.mockito.Mockito.when;
 
 public class ReusabilityUnitTests {
 
-    @Nested
     @ParameterizedClass
     @MethodSource("data")
     @RequiredArgsConstructor
     @FieldDefaults(makeFinal = true)
-    public class CanBeReusedTest {
-        public Object[][] data() {
+    public static class CanBeReusedTest {
+
+        public static Object[][] data() {
             return new Object[][] {
                 { "generic", new GenericContainer<>(TestImages.TINY_IMAGE), true },
                 { "anonymous generic", new GenericContainer(TestImages.TINY_IMAGE) {}, true },
@@ -86,14 +85,14 @@ public class ReusabilityUnitTests {
             }
         }
 
-        class CustomContainer extends GenericContainer<CustomContainer> {
+        static class CustomContainer extends GenericContainer<CustomContainer> {
 
             CustomContainer() {
                 super(TestImages.TINY_IMAGE);
             }
         }
 
-        class CustomContainerWithContainerIsCreated
+        static class CustomContainerWithContainerIsCreated
             extends GenericContainer<CustomContainerWithContainerIsCreated> {
 
             CustomContainerWithContainerIsCreated() {
@@ -107,10 +106,8 @@ public class ReusabilityUnitTests {
         }
     }
 
-    @Nested
-    @RunWith(BlockJUnit4ClassRunner.class)
     @FieldDefaults(makeFinal = true)
-    public class HooksTest extends AbstractReusabilityTest {
+    public static class HooksTest extends AbstractReusabilityTest {
 
         List<String> script = new ArrayList<>();
 
@@ -189,10 +186,8 @@ public class ReusabilityUnitTests {
         }
     }
 
-    @Nested
-    @RunWith(BlockJUnit4ClassRunner.class)
     @FieldDefaults(makeFinal = true)
-    public class HashTest extends AbstractReusabilityTest {
+    public static class HashTest extends AbstractReusabilityTest {
 
         protected GenericContainer<?> container = makeReusable(
             new GenericContainer(TestImages.TINY_IMAGE) {
@@ -304,22 +299,20 @@ public class ReusabilityUnitTests {
         }
     }
 
-
-    interface TestStrategy {
-        void withCopyFileToContainer(MountableFile mountableFile, String path);
-
-        void clear();
-    }
-
-    @Nested
     @ParameterizedClass
     @MethodSource("strategies")
     @FieldDefaults(makeFinal = true)
-    public class CopyFilesHashTest {
+    public static class CopyFilesHashTest {
 
         private final TestStrategy strategy;
 
-        private class MountableFileTestStrategy implements TestStrategy {
+        interface TestStrategy {
+            void withCopyFileToContainer(MountableFile mountableFile, String path);
+
+            void clear();
+        }
+
+        private static class MountableFileTestStrategy implements TestStrategy {
 
             private final GenericContainer<?> container;
 
@@ -338,7 +331,7 @@ public class ReusabilityUnitTests {
             }
         }
 
-        private class TransferableTestStrategy implements TestStrategy {
+        private static class TransferableTestStrategy implements TestStrategy {
 
             private final GenericContainer<?> container;
 
@@ -357,7 +350,7 @@ public class ReusabilityUnitTests {
             }
         }
 
-        public List<Function<GenericContainer<?>, TestStrategy>> strategies() {
+        public static List<Function<GenericContainer<?>, TestStrategy>> strategies() {
             return Arrays.asList(MountableFileTestStrategy::new, TransferableTestStrategy::new);
         }
 
@@ -508,11 +501,9 @@ public class ReusabilityUnitTests {
         }
     }
 
+    @ExtendWith(MockTestcontainersConfigurationExtension.class)
     @FieldDefaults(makeFinal = true)
-    public abstract class AbstractReusabilityTest {
-
-        @Rule
-        public MockTestcontainersConfigurationRule configurationMock = new MockTestcontainersConfigurationRule();
+    public abstract static class AbstractReusabilityTest {
 
         protected DockerClient client = Mockito.mock(DockerClient.class);
 

--- a/core/src/test/java/org/testcontainers/images/OverrideImagePullPolicyTest.java
+++ b/core/src/test/java/org/testcontainers/images/OverrideImagePullPolicyTest.java
@@ -3,22 +3,18 @@ package org.testcontainers.images;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.testcontainers.DockerRegistryContainer;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.FakeImagePullPolicy;
-import org.testcontainers.utility.MockTestcontainersConfigurationRule;
+import org.testcontainers.utility.MockTestcontainersConfigurationExtension;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Testcontainers
+@ExtendWith(MockTestcontainersConfigurationExtension.class)
 public class OverrideImagePullPolicyTest {
-
-    @Container
-    public MockTestcontainersConfigurationRule config = new MockTestcontainersConfigurationRule();
 
     private ImagePullPolicy originalInstance;
 

--- a/core/src/test/java/org/testcontainers/utility/DefaultImageNameSubstitutorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/DefaultImageNameSubstitutorTest.java
@@ -2,14 +2,13 @@ package org.testcontainers.utility;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 
-@Testcontainers
+@ExtendWith(MockTestcontainersConfigurationExtension.class)
 public class DefaultImageNameSubstitutorTest {
 
     public static final DockerImageName ORIGINAL_IMAGE = DockerImageName.parse("foo");
@@ -17,9 +16,6 @@ public class DefaultImageNameSubstitutorTest {
     public static final DockerImageName SUBSTITUTE_IMAGE = DockerImageName.parse("bar");
 
     private ConfigurationFileImageNameSubstitutor underTest;
-
-    @Container
-    public MockTestcontainersConfigurationRule config = new MockTestcontainersConfigurationRule();
 
     @BeforeEach
     public void setUp() {

--- a/core/src/test/java/org/testcontainers/utility/ImageNameSubstitutorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/ImageNameSubstitutorTest.java
@@ -3,11 +3,10 @@ package org.testcontainers.utility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.FileWriter;
 import java.io.IOException;
@@ -21,14 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 
-@Testcontainers
+@ExtendWith(MockTestcontainersConfigurationExtension.class)
 public class ImageNameSubstitutorTest {
 
     @TempDir
     public Path tempFolder;
-
-    @Container
-    public MockTestcontainersConfigurationRule config = new MockTestcontainersConfigurationRule();
 
     private ImageNameSubstitutor originalInstance;
 

--- a/core/src/test/java/org/testcontainers/utility/MockTestcontainersConfigurationExtension.java
+++ b/core/src/test/java/org/testcontainers/utility/MockTestcontainersConfigurationExtension.java
@@ -1,0 +1,41 @@
+package org.testcontainers.utility;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.mockito.Mockito;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * This extension applies a spy on {@link TestcontainersConfiguration}
+ * for testing features that depend on the global configuration.
+ */
+public final class MockTestcontainersConfigurationExtension implements Extension, AfterEachCallback, BeforeEachCallback {
+
+    private static final Namespace NAMESPACE = Namespace.create(MockTestcontainersConfigurationExtension.class);
+
+    private static final String PREVIOUS_REF = "previousRef";
+
+    private static AtomicReference<TestcontainersConfiguration> REF = TestcontainersConfiguration.getInstanceField();
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        TestcontainersConfiguration previous = REF.get();
+        if (previous == null) {
+            previous = TestcontainersConfiguration.getInstance();
+        }
+        REF.set(Mockito.spy(previous));
+        context.getStore(NAMESPACE).put(PREVIOUS_REF, previous);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        TestcontainersConfiguration previous = context.getStore(NAMESPACE).get(PREVIOUS_REF, TestcontainersConfiguration.class);
+        REF.set(previous);
+        Mockito.validateMockitoUsage();
+    }
+}


### PR DESCRIPTION
This is the replacement for MockTestcontainersConfigurationRule for internal
JUnit Jupiter tests.

This change removes references to BlockJUnit4ClassRunner.

Tested with:

./gradlew :testcontainers:test --tests 'org.testcontainers.containers.ReusabilityUnitTests$*'